### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -75,8 +75,8 @@ top5 = AverageMeter()
 end = time.time()
 for i, (_input, target) in enumerate(data_loader):
 	if torch.cuda.is_available():
-		target = target.cuda(async=True)
-		_input = _input.cuda(async=True)
+		target = target.cuda(non_blocking=True)
+		_input = _input.cuda(non_blocking=True)
 	input_var = torch.autograd.Variable(_input, volatile=True)
 	target_var = torch.autograd.Variable(target, volatile=True)
 


### PR DESCRIPTION
Cuda has moved from using '__async__' --> '__non_blocking__'.

[flake8](http://flake8.pycqa.org) testing of https://github.com/MIT-HAN-LAB/ProxylessNAS on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./eval.py:78:28: E999 SyntaxError: invalid syntax
		target = target.cuda(async=True)
                           ^
1     E999 SyntaxError: invalid syntax
1
```